### PR TITLE
refactor: enforce IReadOnlyList return types across CQRS chain + hard…

### DIFF
--- a/VAH.Backend/CQRS/Assets/Commands/AssetCommands.cs
+++ b/VAH.Backend/CQRS/Assets/Commands/AssetCommands.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using MediatR;
 using VAH.Backend.Models;
 
@@ -14,7 +13,7 @@ public sealed record UploadFilesCommand(
     IReadOnlyCollection<UploadedFileDto> Files,
     int CollectionId,
     int? FolderId,
-    string UserId) : IRequest<List<AssetResponseDto>>;
+    string UserId) : IRequest<IReadOnlyList<AssetResponseDto>>;
 
 /// <summary>Command: Partial update of an asset (rename, move, regroup).</summary>
 public sealed record UpdateAssetCommand(

--- a/VAH.Backend/CQRS/Assets/Handlers/AssetCommandHandlers.cs
+++ b/VAH.Backend/CQRS/Assets/Handlers/AssetCommandHandlers.cs
@@ -15,9 +15,9 @@ public sealed class CreateAssetHandler(IAssetService assetService)
 
 /// <summary>Handler: Upload one or more files to a collection.</summary>
 public sealed class UploadFilesHandler(IAssetService assetService)
-    : IRequestHandler<UploadFilesCommand, List<AssetResponseDto>>
+    : IRequestHandler<UploadFilesCommand, IReadOnlyList<AssetResponseDto>>
 {
-    public Task<List<AssetResponseDto>> Handle(UploadFilesCommand request, CancellationToken ct)
+    public Task<IReadOnlyList<AssetResponseDto>> Handle(UploadFilesCommand request, CancellationToken ct)
         => assetService.UploadFilesAsync(request.Files, request.CollectionId, request.FolderId, request.UserId, ct);
 }
 

--- a/VAH.Backend/CQRS/Assets/Handlers/AssetQueryHandlers.cs
+++ b/VAH.Backend/CQRS/Assets/Handlers/AssetQueryHandlers.cs
@@ -23,8 +23,8 @@ public sealed class GetAssetByIdHandler(IAssetService assetService)
 
 /// <summary>Handler: Assets belonging to a color group.</summary>
 public sealed class GetAssetsByGroupHandler(IAssetService assetService)
-    : IRequestHandler<GetAssetsByGroupQuery, List<AssetResponseDto>>
+    : IRequestHandler<GetAssetsByGroupQuery, IReadOnlyList<AssetResponseDto>>
 {
-    public Task<List<AssetResponseDto>> Handle(GetAssetsByGroupQuery request, CancellationToken ct)
+    public Task<IReadOnlyList<AssetResponseDto>> Handle(GetAssetsByGroupQuery request, CancellationToken ct)
         => assetService.GetAssetsByGroupAsync(request.GroupId, request.UserId, ct);
 }

--- a/VAH.Backend/CQRS/Assets/Queries/AssetQueries.cs
+++ b/VAH.Backend/CQRS/Assets/Queries/AssetQueries.cs
@@ -16,4 +16,4 @@ public sealed record GetAssetByIdQuery(
 /// <summary>Query: Assets belonging to a color group.</summary>
 public sealed record GetAssetsByGroupQuery(
     int GroupId,
-    string UserId) : IRequest<List<AssetResponseDto>>;
+    string UserId) : IRequest<IReadOnlyList<AssetResponseDto>>;

--- a/VAH.Backend/Configuration/AssetOptions.cs
+++ b/VAH.Backend/Configuration/AssetOptions.cs
@@ -1,10 +1,16 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace VAH.Backend.Configuration;
 
 /// <summary>
-/// Holds adjustable defaults for assets to avoid hard-coded values in controllers.
+/// Configurable defaults for the Asset module.
+/// Bound from <c>appsettings.json</c> section <see cref="SectionName"/>.
 /// </summary>
 public sealed class AssetOptions
 {
     public const string SectionName = "AssetDefaults";
+
+    /// <summary>Collection ID assigned to newly uploaded assets when none is specified.</summary>
+    [Range(1, int.MaxValue)]
     public int DefaultCollectionId { get; init; } = 1;
 }

--- a/VAH.Backend/Extensions/ServiceCollectionExtensions.cs
+++ b/VAH.Backend/Extensions/ServiceCollectionExtensions.cs
@@ -308,7 +308,10 @@ public static class ServiceCollectionExtensions
     private static IServiceCollection AddAssetModule(
         this IServiceCollection services, IConfiguration configuration)
     {
-        services.Configure<AssetOptions>(configuration.GetSection(AssetOptions.SectionName));
+        services.AddOptions<AssetOptions>()
+            .Bind(configuration.GetSection(AssetOptions.SectionName))
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
 
         services.AddScoped<IStorageService, LocalStorageService>();
         services.AddScoped<IFileMapperService, FileMapperService>();

--- a/VAH.Backend/Features/Assets/Application/AssetApplicationService.cs
+++ b/VAH.Backend/Features/Assets/Application/AssetApplicationService.cs
@@ -41,13 +41,13 @@ internal sealed class AssetApplicationService : IAssetApplicationService
     public Task<AssetResponseDto> GetAssetByIdAsync(int id, CancellationToken ct = default)
         => _sender.Send(new GetAssetByIdQuery(id, CurrentUserId), ct);
 
-    public Task<List<AssetResponseDto>> GetAssetsByGroupAsync(int groupId, CancellationToken ct = default)
+    public Task<IReadOnlyList<AssetResponseDto>> GetAssetsByGroupAsync(int groupId, CancellationToken ct = default)
         => _sender.Send(new GetAssetsByGroupQuery(groupId, CurrentUserId), ct);
 
     public Task<AssetResponseDto> CreateAssetAsync(CreateAssetDto dto, CancellationToken ct = default)
         => _sender.Send(new CreateAssetCommand(dto, CurrentUserId), ct);
 
-    public Task<List<AssetResponseDto>> UploadFilesAsync(IReadOnlyCollection<UploadedFileDto> files, int? collectionId, int? folderId, CancellationToken ct = default)
+    public Task<IReadOnlyList<AssetResponseDto>> UploadFilesAsync(IReadOnlyCollection<UploadedFileDto> files, int? collectionId, int? folderId, CancellationToken ct = default)
     {
         var targetCollectionId = collectionId ?? DefaultCollectionId;
         var payload = files ?? Array.Empty<UploadedFileDto>();

--- a/VAH.Backend/Features/Assets/Application/IAssetApplicationService.cs
+++ b/VAH.Backend/Features/Assets/Application/IAssetApplicationService.cs
@@ -9,9 +9,9 @@ public interface IAssetApplicationService
 {
     Task<PagedResult<AssetResponseDto>> GetAssetsAsync(PaginationParams pagination, CancellationToken ct = default);
     Task<AssetResponseDto> GetAssetByIdAsync(int id, CancellationToken ct = default);
-    Task<List<AssetResponseDto>> GetAssetsByGroupAsync(int groupId, CancellationToken ct = default);
+    Task<IReadOnlyList<AssetResponseDto>> GetAssetsByGroupAsync(int groupId, CancellationToken ct = default);
     Task<AssetResponseDto> CreateAssetAsync(CreateAssetDto dto, CancellationToken ct = default);
-    Task<List<AssetResponseDto>> UploadFilesAsync(IReadOnlyCollection<UploadedFileDto> files, int? collectionId, int? folderId, CancellationToken ct = default);
+    Task<IReadOnlyList<AssetResponseDto>> UploadFilesAsync(IReadOnlyCollection<UploadedFileDto> files, int? collectionId, int? folderId, CancellationToken ct = default);
     Task<AssetResponseDto> UpdateAssetAsync(int id, UpdateAssetDto dto, CancellationToken ct = default);
     Task DeleteAssetAsync(int id, CancellationToken ct = default);
     Task<AssetResponseDto> DuplicateAssetAsync(int id, int? targetFolderId, CancellationToken ct = default);

--- a/VAH.Backend/Services/AssetService.cs
+++ b/VAH.Backend/Services/AssetService.cs
@@ -127,7 +127,7 @@ public class AssetService : IAssetService
         return asset.ToDto();
     }
 
-    public async Task<List<AssetResponseDto>> UploadFilesAsync(IReadOnlyCollection<UploadedFileDto> files, int collectionId, int? folderId, string userId, CancellationToken ct = default)
+    public async Task<IReadOnlyList<AssetResponseDto>> UploadFilesAsync(IReadOnlyCollection<UploadedFileDto> files, int collectionId, int? folderId, string userId, CancellationToken ct = default)
     {
         if (files == null || files.Count == 0)
             throw new ArgumentException("No files uploaded.");
@@ -363,7 +363,7 @@ public class AssetService : IAssetService
         await _context.SaveChangesAsync(ct);
     }
 
-    public async Task<List<AssetResponseDto>> GetAssetsByGroupAsync(int groupId, string userId, CancellationToken ct = default)
+    public async Task<IReadOnlyList<AssetResponseDto>> GetAssetsByGroupAsync(int groupId, string userId, CancellationToken ct = default)
     {
         var candidates = await _context.Assets
             .Where(a => a.GroupId == groupId)

--- a/VAH.Backend/Services/IAssetService.cs
+++ b/VAH.Backend/Services/IAssetService.cs
@@ -8,7 +8,7 @@ public interface IAssetService
     Task<PagedResult<AssetResponseDto>> GetAssetsAsync(PaginationParams pagination, string userId, CancellationToken ct = default);
     Task<AssetResponseDto> GetByIdAsync(int id, string userId, CancellationToken ct = default);
     Task<AssetResponseDto> CreateAssetAsync(CreateAssetDto dto, string userId, CancellationToken ct = default);
-    Task<List<AssetResponseDto>> UploadFilesAsync(IReadOnlyCollection<UploadedFileDto> files, int collectionId, int? folderId, string userId, CancellationToken ct = default);
+    Task<IReadOnlyList<AssetResponseDto>> UploadFilesAsync(IReadOnlyCollection<UploadedFileDto> files, int collectionId, int? folderId, string userId, CancellationToken ct = default);
     Task<AssetResponseDto> UpdatePositionAsync(int id, double positionX, double positionY, string userId, CancellationToken ct = default);
     Task<AssetResponseDto> CreateFolderAsync(CreateFolderDto dto, string userId, CancellationToken ct = default);
     Task<AssetResponseDto> CreateColorAsync(CreateColorDto dto, string userId, CancellationToken ct = default);
@@ -17,6 +17,6 @@ public interface IAssetService
     Task<AssetResponseDto> UpdateAssetAsync(int id, UpdateAssetDto dto, string userId, CancellationToken ct = default);
     Task<bool> DeleteAssetAsync(int id, string userId, CancellationToken ct = default);
     Task ReorderAssetsAsync(List<int> assetIds, string userId, CancellationToken ct = default);
-    Task<List<AssetResponseDto>> GetAssetsByGroupAsync(int groupId, string userId, CancellationToken ct = default);
+    Task<IReadOnlyList<AssetResponseDto>> GetAssetsByGroupAsync(int groupId, string userId, CancellationToken ct = default);
     Task<AssetResponseDto> DuplicateAssetAsync(int id, int? targetFolderId, string userId, CancellationToken ct = default);
 }

--- a/docs/07_CHANGELOG/CHANGELOG.md
+++ b/docs/07_CHANGELOG/CHANGELOG.md
@@ -12,6 +12,28 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ---
 
+## [0.5.1] — 2026-03-12
+
+### Changed — CQRS Immutability Hardening
+
+- **`UploadFilesCommand`**: Return type `List<AssetResponseDto>` → `IReadOnlyList<AssetResponseDto>` — immutable output consistent with immutable input (`IReadOnlyCollection`)
+- **`GetAssetsByGroupQuery`**: Return type `List<AssetResponseDto>` → `IReadOnlyList<AssetResponseDto>` — query results should never be mutated by callers
+- **Full chain updated** (10 files): Command/Query → Handler → IAssetService → AssetService → IAssetApplicationService → AssetApplicationService
+- **Removed redundant `using System.Collections.Generic`** from `AssetCommands.cs` (covered by implicit usings since .NET 6)
+
+### Changed — AssetOptions Validation
+
+- **`AssetOptions.DefaultCollectionId`**: Added `[Range(1, int.MaxValue)]` data annotation
+- **Registration upgraded**: `services.Configure<T>()` → `AddOptions<T>().Bind().ValidateDataAnnotations().ValidateOnStart()` — fail-fast on startup if config is invalid
+- **XML docs enhanced**: `<see cref="SectionName"/>` linking, property-level summary
+
+### Metrics
+- 10 files changed (+25 / −17 lines)
+- All CQRS collection return types now `IReadOnlyList<T>` — zero mutable collections exposed
+- `AssetOptions` registration now consistent with `FileUploadConfig` pattern
+
+---
+
 ## [0.5.0] — 2026-03-12
 
 ### Added — New Infrastructure Files

--- a/docs/07_CHANGELOG/REFACTOR_LOG.md
+++ b/docs/07_CHANGELOG/REFACTOR_LOG.md
@@ -6,6 +6,69 @@ Tracks completed refactoring efforts with before/after comparisons.
 
 ---
 
+## RF-011 — CQRS Immutability & AssetOptions Hardening
+
+**Date**: 2026-03-12
+**Scope**: CQRS layer (Commands, Queries, Handlers), Service interfaces/implementations, AssetOptions, ServiceCollectionExtensions
+**Branch**: `refactor/cqrs-immutability-options-hardening`
+
+### Summary
+
+Enforced immutable collection contracts across the entire CQRS → Service chain. Hardened `AssetOptions` with data annotation validation and fail-fast startup registration.
+
+### Key Changes
+
+#### 1. IReadOnlyList<T> Return Types (Full Chain)
+
+**Before**
+```csharp
+// Command returns mutable List
+public sealed record UploadFilesCommand(...) : IRequest<List<AssetResponseDto>>;
+// Query returns mutable List
+public sealed record GetAssetsByGroupQuery(...) : IRequest<List<AssetResponseDto>>;
+```
+
+**After**
+```csharp
+// Immutable — callers cannot add/remove from results
+public sealed record UploadFilesCommand(...) : IRequest<IReadOnlyList<AssetResponseDto>>;
+public sealed record GetAssetsByGroupQuery(...) : IRequest<IReadOnlyList<AssetResponseDto>>;
+```
+
+Updated in all 6 layers: Command/Query record → Handler → IAssetService → AssetService → IAssetApplicationService → AssetApplicationService.
+
+#### 2. AssetOptions — Validation + Registration
+
+**Before**
+```csharp
+public int DefaultCollectionId { get; init; } = 1;
+// Registration: services.Configure<AssetOptions>(...)
+```
+
+**After**
+```csharp
+[Range(1, int.MaxValue)]
+public int DefaultCollectionId { get; init; } = 1;
+// Registration: AddOptions<T>().Bind().ValidateDataAnnotations().ValidateOnStart()
+```
+
+### Files Changed
+
+| File | Change |
+|---|---|
+| `CQRS/Assets/Commands/AssetCommands.cs` | `List<>` → `IReadOnlyList<>`, removed redundant using |
+| `CQRS/Assets/Queries/AssetQueries.cs` | `List<>` → `IReadOnlyList<>` |
+| `CQRS/Assets/Handlers/AssetCommandHandlers.cs` | Handler return type updated |
+| `CQRS/Assets/Handlers/AssetQueryHandlers.cs` | Handler return type updated |
+| `Services/IAssetService.cs` | Interface signatures updated |
+| `Services/AssetService.cs` | Implementation signatures updated |
+| `Features/Assets/Application/IAssetApplicationService.cs` | Interface signatures updated |
+| `Features/Assets/Application/AssetApplicationService.cs` | Implementation signatures updated |
+| `Configuration/AssetOptions.cs` | `[Range]` + enhanced XML docs |
+| `Extensions/ServiceCollectionExtensions.cs` | `ValidateDataAnnotations().ValidateOnStart()` |
+
+---
+
 ## RF-010 — Program.cs Three-Tier Bootstrap & Production Infrastructure
 
 **Date**: 2026-03-12


### PR DESCRIPTION
…en AssetOptions

- UploadFilesCommand: List<T>  IReadOnlyList<T> (immutable output)
- GetAssetsByGroupQuery: List<T>  IReadOnlyList<T> (query results immutable)
- Full chain updated: Command/Query  Handler  Service interface  Service impl  AppService
- AssetOptions: add [Range(1, int.MaxValue)] + ValidateDataAnnotations().ValidateOnStart()
- Remove redundant using System.Collections.Generic (implicit usings)
- 10 files changed, build: 0 errors, 0 warnings