### PR TITLE
refactor: harden Asset domain model  abstract base, private setters, …

### DIFF
--- a/VAH.Backend/Data/AppDbContext.cs
+++ b/VAH.Backend/Data/AppDbContext.cs
@@ -31,7 +31,7 @@ public class AppDbContext : IdentityDbContext<ApplicationUser>
 
             // TPH inheritance — use existing ContentType column as discriminator
             entity.HasDiscriminator(a => a.ContentType)
-                  .HasValue<Asset>(AssetContentType.File)
+                  .HasValue<FileAsset>(AssetContentType.File)
                   .HasValue<ImageAsset>(AssetContentType.Image)
                   .HasValue<LinkAsset>(AssetContentType.Link)
                   .HasValue<ColorAsset>(AssetContentType.Color)
@@ -41,8 +41,13 @@ public class AppDbContext : IdentityDbContext<ApplicationUser>
             // Ignore virtual behavior properties (not mapped to DB)
             entity.Ignore(a => a.HasPhysicalFile);
             entity.Ignore(a => a.CanHaveThumbnails);
-            entity.Ignore(a => a.RequiresFileCleanup);
             entity.Ignore(a => a.IsSystemAsset);
+
+            // Soft-delete filter — exclude deleted assets from all queries by default
+            entity.HasQueryFilter(a => !a.IsDeleted);
+            entity.HasIndex(a => a.IsDeleted)
+                  .HasDatabaseName("IX_Assets_IsDeleted")
+                  .HasFilter("IsDeleted = 0");
 
             // FK: Asset → Collection (with navigation)
             entity.HasOne(a => a.Collection)
@@ -79,7 +84,9 @@ public class AppDbContext : IdentityDbContext<ApplicationUser>
             // Property constraints
             entity.Property(a => a.FileName).HasMaxLength(500);
             entity.Property(a => a.FilePath).HasMaxLength(2048);
+#pragma warning disable CS0618
             entity.Property(a => a.Tags).HasMaxLength(2000);
+#pragma warning restore CS0618
 
             // Enum → string conversion (backward compat with existing DB)
             entity.Property(a => a.ContentType)
@@ -87,6 +94,17 @@ public class AppDbContext : IdentityDbContext<ApplicationUser>
                   .HasConversion(
                       v => v.ToDbString(),
                       v => v.ToAssetContentType());
+        });
+
+        // ── TPH subtype-specific columns (nullable in shared table) ──
+        modelBuilder.Entity<LinkAsset>(entity =>
+        {
+            entity.Property(l => l.Url).HasMaxLength(2048);
+        });
+
+        modelBuilder.Entity<ColorAsset>(entity =>
+        {
+            entity.Property(c => c.HexCode).HasMaxLength(50);
         });
 
         // ── Collection table configuration ──

--- a/VAH.Backend/Models/Asset.cs
+++ b/VAH.Backend/Models/Asset.cs
@@ -4,58 +4,92 @@ using System.Text.Json.Serialization;
 namespace VAH.Backend.Models;
 
 /// <summary>
-/// Base class for all digital assets in the system (TPH base).
-/// Default discriminator value: File. Subtypes: ImageAsset, LinkAsset,
-/// ColorAsset, ColorGroupAsset, FolderAsset.
+/// Abstract base for all digital assets (TPH root).
+/// Never instantiate directly — use a concrete subtype via AssetFactory.
+/// All state mutations go through domain methods; setters are private.
+/// Subtypes: FileAsset, ImageAsset, LinkAsset, ColorAsset, ColorGroupAsset, FolderAsset.
 /// </summary>
-public class Asset
+public abstract class Asset
 {
+    // ── Constructors ──
+
+    /// <summary>EF Core materialization (reflection can set private setters).</summary>
+    protected Asset() { }
+
+    /// <summary>Domain constructor — called by subclass constructors via base(...).</summary>
+    protected Asset(
+        string fileName, string filePath, AssetContentType contentType,
+        int collectionId, string userId,
+        int? parentFolderId = null, int? groupId = null,
+        int sortOrder = 0, bool isFolder = false)
+    {
+        FileName = fileName;
+        FilePath = filePath;
+        ContentType = contentType;
+        CollectionId = collectionId;
+        UserId = userId;
+        ParentFolderId = parentFolderId;
+        GroupId = groupId;
+        SortOrder = sortOrder;
+        IsFolder = isFolder;
+        CreatedAt = DateTime.UtcNow;
+    }
+
+    // ── Persisted properties (private set — mutation via domain methods only) ──
+
     [Key]
-    public int Id { get; set; }
+    public int Id { get; private set; }
 
     [Required, MaxLength(500)]
-    public string FileName { get; set; } = string.Empty;
+    public string FileName { get; private set; } = string.Empty;
 
     [Required, MaxLength(2048)]
-    public string FilePath { get; set; } = string.Empty;
+    public string FilePath { get; private set; } = string.Empty;
 
+    /// <summary>Legacy comma-separated tags. Use AssetTags navigation for new code.</summary>
+    [Obsolete("Use AssetTags navigation property instead. Kept for backward-compatible search queries.")]
     [MaxLength(2000)]
-    public string Tags { get; set; } = string.Empty;
+    public string Tags { get; internal set; } = string.Empty;
 
-    public DateTime CreatedAt { get; set; }
+    public DateTime CreatedAt { get; private set; }
 
-    public double PositionX { get; set; } = 0;
-    public double PositionY { get; set; } = 0;
+    // ── Audit ──
 
-    public int CollectionId { get; set; } = 1;
+    public DateTime? UpdatedAt { get; private set; }
 
-    public AssetContentType ContentType { get; set; } = AssetContentType.File;
+    /// <summary>Soft-delete flag. True = logically deleted.</summary>
+    public bool IsDeleted { get; private set; }
 
-    public int? GroupId { get; set; } = null;
-    public int? ParentFolderId { get; set; } = null;
-    public int SortOrder { get; set; } = 0;
-    public bool IsFolder { get; set; } = false;
+    public double PositionX { get; private set; }
+    public double PositionY { get; private set; }
 
-    /// <summary>
-    /// Owner of this asset. Null for system/shared assets.
-    /// </summary>
-    public string? UserId { get; set; }
+    public int CollectionId { get; private set; }
+
+    public AssetContentType ContentType { get; private set; } = AssetContentType.File;
+
+    public int? GroupId { get; private set; }
+    public int? ParentFolderId { get; private set; }
+    public int SortOrder { get; private set; }
+    public bool IsFolder { get; private set; }
+
+    /// <summary>Owner of this asset. Null for system/shared assets.</summary>
+    public string? UserId { get; private set; }
 
     // --- Thumbnails (generated server-side for images) ---
 
-    /// <summary>Small thumbnail (150px max), WebP. Null if not an image or not yet generated.</summary>
+    /// <summary>Small thumbnail (150px max), WebP.</summary>
     [MaxLength(2048)]
-    public string? ThumbnailSm { get; set; }
+    public string? ThumbnailSm { get; private set; }
 
     /// <summary>Medium thumbnail (400px max), WebP.</summary>
     [MaxLength(2048)]
-    public string? ThumbnailMd { get; set; }
+    public string? ThumbnailMd { get; private set; }
 
     /// <summary>Large thumbnail (800px max), WebP.</summary>
     [MaxLength(2048)]
-    public string? ThumbnailLg { get; set; }
+    public string? ThumbnailLg { get; private set; }
 
-    // --- Navigation properties ---
+    // --- Navigation properties (EF Core manages these) ---
     public ICollection<AssetTag> AssetTags { get; set; } = new List<AssetTag>();
 
     /// <summary>Parent collection this asset belongs to.</summary>
@@ -74,11 +108,7 @@ public class Asset
     /// <summary>Whether thumbnails can/should be generated for this asset type.</summary>
     public virtual bool CanHaveThumbnails => false;
 
-    /// <summary>Whether physical file cleanup is needed on delete.</summary>
-    public virtual bool RequiresFileCleanup =>
-        HasPhysicalFile && !string.IsNullOrEmpty(FilePath) && FilePath.StartsWith("/uploads/");
-
-    // ── Domain behavior methods ──
+    // ── Domain behavior methods (the ONLY way to mutate state) ──
 
     /// <summary>Update canvas position coordinates.</summary>
     public void UpdatePosition(double x, double y)
@@ -87,21 +117,33 @@ public class Asset
         PositionY = y;
     }
 
-    /// <summary>Apply partial update from DTO. Only non-null fields are applied.</summary>
-    public void ApplyUpdate(UpdateAssetDto dto)
+    /// <summary>Rename this asset.</summary>
+    public void Rename(string newName)
     {
-        if (!string.IsNullOrEmpty(dto.FileName))
-            FileName = dto.FileName.Trim();
-        if (dto.SortOrder.HasValue)
-            SortOrder = dto.SortOrder.Value;
-        if (dto.ClearGroup == true)
-            GroupId = null;
-        else if (dto.GroupId.HasValue)
-            GroupId = dto.GroupId.Value;
-        if (dto.ParentFolderId.HasValue)
-            ParentFolderId = dto.ParentFolderId.Value;
-        if (dto.ClearParentFolder == true)
-            ParentFolderId = null;
+        ArgumentException.ThrowIfNullOrWhiteSpace(newName);
+        FileName = newName.Trim();
+        UpdatedAt = DateTime.UtcNow;
+    }
+
+    /// <summary>Change the sort position of this asset.</summary>
+    public void Reorder(int sortOrder)
+    {
+        SortOrder = sortOrder;
+        UpdatedAt = DateTime.UtcNow;
+    }
+
+    /// <summary>Assign this asset to a color group.</summary>
+    public void AssignToGroup(int groupId)
+    {
+        GroupId = groupId;
+        UpdatedAt = DateTime.UtcNow;
+    }
+
+    /// <summary>Remove this asset from its current color group.</summary>
+    public void RemoveFromGroup()
+    {
+        GroupId = null;
+        UpdatedAt = DateTime.UtcNow;
     }
 
     /// <summary>Set generated thumbnail paths.</summary>
@@ -113,10 +155,18 @@ public class Asset
     }
 
     /// <summary>Move asset to a different folder (or root if null).</summary>
-    public void MoveToFolder(int? folderId) => ParentFolderId = folderId;
+    public void MoveToFolder(int? folderId)
+    {
+        ParentFolderId = folderId;
+        UpdatedAt = DateTime.UtcNow;
+    }
 
     /// <summary>Move asset to a different collection.</summary>
-    public void MoveToCollection(int collectionId) => CollectionId = collectionId;
+    public void MoveToCollection(int collectionId)
+    {
+        CollectionId = collectionId;
+        UpdatedAt = DateTime.UtcNow;
+    }
 
     /// <summary>Check if this asset is owned by a specific user.</summary>
     public bool IsOwnedBy(string userId) => UserId == userId;
@@ -124,26 +174,36 @@ public class Asset
     /// <summary>Whether this is a system/shared asset (no owner).</summary>
     public bool IsSystemAsset => UserId == null;
 
-    // ── Mapping ──
-
-    /// <summary>Map this entity to the API response DTO.</summary>
-    public AssetResponseDto ToDto() => new()
+    /// <summary>Mark this asset as soft-deleted.</summary>
+    public void SoftDelete()
     {
-        Id = Id,
-        FileName = FileName,
-        FilePath = FilePath,
-        Tags = Tags,
-        CreatedAt = CreatedAt,
-        PositionX = PositionX,
-        PositionY = PositionY,
-        CollectionId = CollectionId,
-        ContentType = ContentType,
-        GroupId = GroupId,
-        ParentFolderId = ParentFolderId,
-        SortOrder = SortOrder,
-        IsFolder = IsFolder,
-        ThumbnailSm = ThumbnailSm,
-        ThumbnailMd = ThumbnailMd,
-        ThumbnailLg = ThumbnailLg,
-    };
+        IsDeleted = true;
+        UpdatedAt = DateTime.UtcNow;
+    }
+
+    // ── Clone support (internal — used by AssetFactory.Duplicate) ──
+
+    /// <summary>
+    /// Copy all shared base-class properties from a source asset.
+    /// Subtype-specific properties are handled by overriding this method.
+    /// </summary>
+    internal virtual void InitializeClone(Asset source, string userId, string copySuffix, int? targetFolderId)
+    {
+        FileName = source.FileName + copySuffix;
+        FilePath = source.FilePath;
+#pragma warning disable CS0618
+        Tags = source.Tags;
+#pragma warning restore CS0618
+        CollectionId = source.CollectionId;
+        ContentType = source.ContentType;
+        GroupId = source.GroupId;
+        ParentFolderId = targetFolderId ?? source.ParentFolderId;
+        SortOrder = source.SortOrder + 1;
+        IsFolder = source.IsFolder;
+        ThumbnailSm = source.ThumbnailSm;
+        ThumbnailMd = source.ThumbnailMd;
+        ThumbnailLg = source.ThumbnailLg;
+        UserId = userId;
+        CreatedAt = DateTime.UtcNow;
+    }
 }

--- a/VAH.Backend/Models/AssetFactory.cs
+++ b/VAH.Backend/Models/AssetFactory.cs
@@ -2,96 +2,75 @@ namespace VAH.Backend.Models;
 
 /// <summary>
 /// Factory for creating the correct Asset subtype.
-/// Ensures each content type is instantiated as its proper TPH class.
-/// ContentType is set explicitly so the in-memory object matches the DB discriminator.
+/// Delegates construction to each subtype's internal constructor,
+/// ensuring TPH discriminator consistency.
+/// Accepts only primitive parameters — never DTOs.
 /// </summary>
 public static class AssetFactory
 {
-    public static ImageAsset CreateImage(string fileName, string filePath, int collectionId, string userId, int? parentFolderId = null) => new()
+    public static ImageAsset CreateImage(string fileName, string filePath, int collectionId, string userId, int? parentFolderId = null)
     {
-        FileName = fileName,
-        FilePath = filePath,
-        Tags = string.Empty,
-        ContentType = AssetContentType.Image,
-        CollectionId = collectionId,
-        ParentFolderId = parentFolderId,
-        CreatedAt = DateTime.UtcNow,
-        UserId = userId,
-    };
+        ArgumentException.ThrowIfNullOrWhiteSpace(fileName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(userId);
 
-    public static Asset CreateFile(string fileName, string filePath, int collectionId, string userId, int? parentFolderId = null) => new()
-    {
-        FileName = fileName,
-        FilePath = filePath,
-        Tags = string.Empty,
-        ContentType = AssetContentType.File,
-        CollectionId = collectionId,
-        ParentFolderId = parentFolderId,
-        CreatedAt = DateTime.UtcNow,
-        UserId = userId,
-    };
+        return new(fileName, filePath, collectionId, userId, parentFolderId);
+    }
 
-    public static FolderAsset CreateFolder(string name, int collectionId, string userId, int? parentFolderId = null) => new()
+    public static FileAsset CreateFile(string fileName, string filePath, int collectionId, string userId, int? parentFolderId = null)
     {
-        FileName = name,
-        FilePath = string.Empty,
-        Tags = string.Empty,
-        ContentType = AssetContentType.Folder,
-        IsFolder = true,
-        CollectionId = collectionId,
-        ParentFolderId = parentFolderId,
-        SortOrder = 0,
-        CreatedAt = DateTime.UtcNow,
-        UserId = userId,
-    };
+        ArgumentException.ThrowIfNullOrWhiteSpace(fileName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(userId);
 
-    public static ColorAsset CreateColor(string colorCode, int collectionId, string userId, string? colorName = null, int? groupId = null, int? parentFolderId = null, int sortOrder = 0) => new()
-    {
-        FileName = colorCode,
-        FilePath = colorCode,
-        Tags = colorName ?? colorCode,
-        ContentType = AssetContentType.Color,
-        CollectionId = collectionId,
-        GroupId = groupId,
-        ParentFolderId = parentFolderId,
-        SortOrder = sortOrder,
-        CreatedAt = DateTime.UtcNow,
-        UserId = userId,
-    };
+        return new(fileName, filePath, collectionId, userId, parentFolderId);
+    }
 
-    public static ColorGroupAsset CreateColorGroup(string groupName, int collectionId, string userId, int? parentFolderId = null, int sortOrder = 0) => new()
+    public static FolderAsset CreateFolder(string name, int collectionId, string userId, int? parentFolderId = null)
     {
-        FileName = groupName,
-        FilePath = string.Empty,
-        Tags = string.Empty,
-        ContentType = AssetContentType.ColorGroup,
-        CollectionId = collectionId,
-        ParentFolderId = parentFolderId,
-        SortOrder = sortOrder,
-        CreatedAt = DateTime.UtcNow,
-        UserId = userId,
-    };
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ArgumentException.ThrowIfNullOrWhiteSpace(userId);
 
-    public static LinkAsset CreateLink(string name, string url, int collectionId, string userId, int? parentFolderId = null) => new()
+        return new(name, collectionId, userId, parentFolderId);
+    }
+
+    public static ColorAsset CreateColor(string colorCode, int collectionId, string userId, string? colorName = null, int? groupId = null, int? parentFolderId = null, int sortOrder = 0)
     {
-        FileName = name,
-        FilePath = url,
-        Tags = string.Empty,
-        ContentType = AssetContentType.Link,
-        CollectionId = collectionId,
-        ParentFolderId = parentFolderId,
-        SortOrder = 0,
-        CreatedAt = DateTime.UtcNow,
-        UserId = userId,
-    };
+        var normalizedCode = AssetValidator.NormalizeHexColor(colorCode);
+        ArgumentException.ThrowIfNullOrWhiteSpace(userId);
+
+        return new(normalizedCode, collectionId, userId, colorName, groupId, parentFolderId, sortOrder);
+    }
+
+    public static ColorGroupAsset CreateColorGroup(string groupName, int collectionId, string userId, int? parentFolderId = null, int sortOrder = 0)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(groupName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(userId);
+
+        return new(groupName, collectionId, userId, parentFolderId, sortOrder);
+    }
+
+    public static LinkAsset CreateLink(string name, string url, int collectionId, string userId, int? parentFolderId = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        var validatedUrl = AssetValidator.ValidateUrl(url);
+        ArgumentException.ThrowIfNullOrWhiteSpace(userId);
+
+        return new(name, validatedUrl, collectionId, userId, parentFolderId);
+    }
 
     /// <summary>
     /// Duplicate an existing asset, creating the correct TPH subtype.
-    /// Copies all shared properties; caller can override specific fields afterward.
+    /// Copies all shared properties via <see cref="Asset.InitializeClone"/>;
+    /// subtype-specific properties (Url, HexCode) are handled by overrides.
     /// </summary>
-    public static Asset Duplicate(Asset source, string userId, int? targetFolderId = null)
+    /// <param name="copySuffix">Localized suffix appended to FileName (e.g. " (copy)", " (bản sao)").</param>
+    public static Asset Duplicate(Asset source, string userId, string copySuffix, int? targetFolderId = null)
     {
-        // Create correct TPH subtype so EF Core sets the discriminator properly
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentException.ThrowIfNullOrWhiteSpace(userId);
+
+        // Create correct TPH subtype (parameterless internal constructors)
         Asset clone = source.ContentType switch
         {
             AssetContentType.Image => new ImageAsset(),
@@ -99,39 +78,12 @@ public static class AssetFactory
             AssetContentType.Color => new ColorAsset(),
             AssetContentType.ColorGroup => new ColorGroupAsset(),
             AssetContentType.Folder => new FolderAsset(),
-            _ => new Asset(),
+            _ => new FileAsset(),
         };
 
-        clone.FileName = source.FileName + " (bản sao)";
-        clone.FilePath = source.FilePath;
-        clone.Tags = source.Tags;
-        clone.CreatedAt = DateTime.UtcNow;
-        clone.CollectionId = source.CollectionId;
-        clone.ContentType = source.ContentType;
-        clone.GroupId = source.GroupId;
-        clone.ParentFolderId = targetFolderId ?? source.ParentFolderId;
-        clone.SortOrder = source.SortOrder + 1;
-        clone.IsFolder = source.IsFolder;
-        clone.UserId = userId;
-        clone.ThumbnailSm = source.ThumbnailSm;
-        clone.ThumbnailMd = source.ThumbnailMd;
-        clone.ThumbnailLg = source.ThumbnailLg;
+        // Virtual dispatch ensures subtype-specific props are copied
+        clone.InitializeClone(source, userId, copySuffix, targetFolderId);
 
         return clone;
     }
-
-    /// <summary>
-    /// Create an Asset from a CreateAssetDto (generic file).
-    /// </summary>
-    public static Asset FromDto(CreateAssetDto dto, string userId) => new()
-    {
-        FileName = dto.FileName.Trim(),
-        FilePath = dto.FilePath.Trim(),
-        Tags = string.Empty,
-        ContentType = AssetContentType.File,
-        CollectionId = dto.CollectionId,
-        ParentFolderId = dto.ParentFolderId,
-        CreatedAt = DateTime.UtcNow,
-        UserId = userId,
-    };
 }

--- a/VAH.Backend/Models/AssetTypes.cs
+++ b/VAH.Backend/Models/AssetTypes.cs
@@ -1,38 +1,116 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace VAH.Backend.Models;
 
 // ──────────────────────────────────────────────────────────────
 //  TPH (Table-Per-Hierarchy) subclasses of Asset.
 //  EF Core materializes the correct subtype based on the
-//  ContentType discriminator column (existing column, no migration).
+//  ContentType discriminator column.
+//  All leaf types are sealed — design intent + JIT devirtualization.
+//  Each type has: internal() for EF Core / Duplicate,
+//  internal(...) for AssetFactory construction.
 // ──────────────────────────────────────────────────────────────
 
-/// <summary>Image asset — uploaded image file with thumbnail support.</summary>
-public class ImageAsset : Asset
+/// <summary>Generic file asset — any uploaded file that isn't a recognized image.</summary>
+public sealed class FileAsset : Asset
 {
+    internal FileAsset() { }
+
+    internal FileAsset(string fileName, string filePath, int collectionId, string userId, int? parentFolderId = null)
+        : base(fileName, filePath, AssetContentType.File, collectionId, userId, parentFolderId) { }
+
+    public override bool HasPhysicalFile => true;
+}
+
+/// <summary>Image asset — uploaded image file with thumbnail support.</summary>
+public sealed class ImageAsset : Asset
+{
+    internal ImageAsset() { }
+
+    internal ImageAsset(string fileName, string filePath, int collectionId, string userId, int? parentFolderId = null)
+        : base(fileName, filePath, AssetContentType.Image, collectionId, userId, parentFolderId) { }
+
     public override bool HasPhysicalFile => true;
     public override bool CanHaveThumbnails => true;
 }
 
 /// <summary>Link/bookmark asset — stores a URL reference.</summary>
-public class LinkAsset : Asset
+public sealed class LinkAsset : Asset
 {
+    internal LinkAsset() { }
+
+    internal LinkAsset(string name, string url, int collectionId, string userId, int? parentFolderId = null)
+        : base(name, url, AssetContentType.Link, collectionId, userId, parentFolderId)
+    {
+        Url = url;
+    }
+
+    /// <summary>The bookmarked URL. Stored separately from FilePath for semantic clarity.</summary>
+    [MaxLength(2048)]
+    public string? Url { get; private set; }
+
     public override bool HasPhysicalFile => false;
+
+    /// <summary>Validate that the URL is a well-formed absolute http(s) URI.</summary>
+    public bool IsValidUrl() =>
+        !string.IsNullOrWhiteSpace(Url)
+        && Uri.TryCreate(Url, UriKind.Absolute, out var uri)
+        && (uri.Scheme == "http" || uri.Scheme == "https");
+
+    internal override void InitializeClone(Asset source, string userId, string copySuffix, int? targetFolderId)
+    {
+        base.InitializeClone(source, userId, copySuffix, targetFolderId);
+        Url = source is LinkAsset link ? link.Url : source.FilePath;
+    }
 }
 
 /// <summary>Color swatch asset — stores a hex color code.</summary>
-public class ColorAsset : Asset
+public sealed class ColorAsset : Asset
 {
+    internal ColorAsset() { }
+
+    internal ColorAsset(string colorCode, int collectionId, string userId,
+        string? colorName = null, int? groupId = null, int? parentFolderId = null, int sortOrder = 0)
+        : base(colorCode, colorCode, AssetContentType.Color, collectionId, userId, parentFolderId, groupId, sortOrder)
+    {
+        HexCode = colorCode;
+#pragma warning disable CS0618
+        Tags = colorName ?? colorCode;
+#pragma warning restore CS0618
+    }
+
+    /// <summary>The hex color code (e.g. #FF5733). Stored separately for semantic clarity.</summary>
+    [MaxLength(50)]
+    public string? HexCode { get; private set; }
+
     public override bool HasPhysicalFile => false;
+
+    internal override void InitializeClone(Asset source, string userId, string copySuffix, int? targetFolderId)
+    {
+        base.InitializeClone(source, userId, copySuffix, targetFolderId);
+        HexCode = source is ColorAsset color ? color.HexCode : source.FilePath;
+    }
 }
 
 /// <summary>Color group — organizes color swatches together.</summary>
-public class ColorGroupAsset : Asset
+public sealed class ColorGroupAsset : Asset
 {
+    internal ColorGroupAsset() { }
+
+    internal ColorGroupAsset(string groupName, int collectionId, string userId,
+        int? parentFolderId = null, int sortOrder = 0)
+        : base(groupName, string.Empty, AssetContentType.ColorGroup, collectionId, userId, parentFolderId, sortOrder: sortOrder) { }
+
     public override bool HasPhysicalFile => false;
 }
 
 /// <summary>Folder — organizes assets hierarchically within a collection.</summary>
-public class FolderAsset : Asset
+public sealed class FolderAsset : Asset
 {
+    internal FolderAsset() { }
+
+    internal FolderAsset(string name, int collectionId, string userId, int? parentFolderId = null)
+        : base(name, string.Empty, AssetContentType.Folder, collectionId, userId, parentFolderId, isFolder: true) { }
+
     public override bool HasPhysicalFile => false;
 }

--- a/VAH.Backend/Models/AssetValidator.cs
+++ b/VAH.Backend/Models/AssetValidator.cs
@@ -1,0 +1,74 @@
+using System.Text.RegularExpressions;
+
+namespace VAH.Backend.Models;
+
+/// <summary>
+/// Centralizes asset domain validation rules.
+/// Called by AssetFactory (pre-construction) and Service layer.
+/// Keeps validation logic DRY and testable in isolation.
+/// </summary>
+public static partial class AssetValidator
+{
+    // ── Color hex code ──
+
+    [GeneratedRegex(@"^#?([0-9A-Fa-f]{3}|[0-9A-Fa-f]{4}|[0-9A-Fa-f]{6}|[0-9A-Fa-f]{8})$")]
+    private static partial Regex HexColorPattern();
+
+    /// <summary>Validate that the color code is a recognized hex format (3/4/6/8 digits, optional #).</summary>
+    public static bool IsValidHexColor(string colorCode) =>
+        !string.IsNullOrWhiteSpace(colorCode) && HexColorPattern().IsMatch(colorCode.Trim());
+
+    /// <summary>
+    /// Normalize a hex color code: trim, auto-prepend # if valid bare hex.
+    /// Returns the normalized code or throws <see cref="ArgumentException"/>.
+    /// </summary>
+    public static string NormalizeHexColor(string colorCode)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(colorCode);
+
+        var code = colorCode.Trim();
+
+        if (!IsValidHexColor(code))
+            throw new ArgumentException($"Invalid hex color code: '{colorCode}'.");
+
+        return code.StartsWith('#') ? code : "#" + code;
+    }
+
+    // ── URL ──
+
+    /// <summary>Validate that the URL is a well-formed absolute http(s) URI.</summary>
+    public static bool IsValidUrl(string url) =>
+        !string.IsNullOrWhiteSpace(url)
+        && Uri.TryCreate(url.Trim(), UriKind.Absolute, out var uri)
+        && (uri.Scheme == "http" || uri.Scheme == "https");
+
+    /// <summary>
+    /// Validate and return normalized URL. Throws <see cref="ArgumentException"/> on failure.
+    /// </summary>
+    public static string ValidateUrl(string url)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(url);
+
+        var trimmed = url.Trim();
+
+        if (!IsValidUrl(trimmed))
+            throw new ArgumentException("Invalid URL format. Must be absolute http or https.");
+
+        return trimmed;
+    }
+
+    // ── File name ──
+
+    /// <summary>Validate that a file name is non-empty and within max length.</summary>
+    public static string ValidateFileName(string fileName, int maxLength = 500)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(fileName);
+
+        var trimmed = fileName.Trim();
+
+        if (trimmed.Length > maxLength)
+            throw new ArgumentException($"File name exceeds maximum length of {maxLength} characters.");
+
+        return trimmed;
+    }
+}

--- a/VAH.Backend/Services/AssetCleanupHelper.cs
+++ b/VAH.Backend/Services/AssetCleanupHelper.cs
@@ -4,6 +4,7 @@ namespace VAH.Backend.Services;
 /// Encapsulates asset file and thumbnail cleanup logic.
 /// Eliminates duplication between DeleteAssetAsync and BulkDeleteAsync.
 /// OOP: Single Responsibility — cleanup is a separate concern from CRUD orchestration.
+/// File cleanup eligibility is determined here (service layer), not in the domain model.
 /// </summary>
 public class AssetCleanupHelper
 {
@@ -17,12 +18,20 @@ public class AssetCleanupHelper
     }
 
     /// <summary>
+    /// Whether a physical file cleanup is needed for this asset.
+    /// Determined by storage service (supports local, S3, Azure, etc.).
+    /// </summary>
+    public bool RequiresFileCleanup(Models.Asset asset) =>
+        asset.HasPhysicalFile
+        && !string.IsNullOrEmpty(asset.FilePath)
+        && _storage.Exists(asset.FilePath);
+
+    /// <summary>
     /// Delete the physical file and any generated thumbnails for an asset.
-    /// Only acts on assets where <see cref="Models.Asset.RequiresFileCleanup"/> is true.
     /// </summary>
     public async Task CleanupFilesAsync(Models.Asset asset)
     {
-        if (!asset.RequiresFileCleanup) return;
+        if (!RequiresFileCleanup(asset)) return;
 
         try
         {

--- a/VAH.Backend/Services/AssetMapper.cs
+++ b/VAH.Backend/Services/AssetMapper.cs
@@ -1,0 +1,44 @@
+using VAH.Backend.Models;
+
+namespace VAH.Backend.Services;
+
+/// <summary>
+/// Maps between Asset domain entities and DTOs.
+/// Keeps the Domain layer free from DTO dependencies.
+/// </summary>
+public static class AssetMapper
+{
+    /// <summary>Map a single Asset entity to the API response DTO.</summary>
+    public static AssetResponseDto ToDto(Asset asset) => new()
+    {
+        Id = asset.Id,
+        FileName = asset.FileName,
+        FilePath = asset.FilePath,
+#pragma warning disable CS0618 // Obsolete Tags — kept for API backward compat
+        Tags = asset.Tags,
+#pragma warning restore CS0618
+        CreatedAt = asset.CreatedAt,
+        PositionX = asset.PositionX,
+        PositionY = asset.PositionY,
+        CollectionId = asset.CollectionId,
+        ContentType = asset.ContentType,
+        GroupId = asset.GroupId,
+        ParentFolderId = asset.ParentFolderId,
+        SortOrder = asset.SortOrder,
+        IsFolder = asset.IsFolder,
+        ThumbnailSm = asset.ThumbnailSm,
+        ThumbnailMd = asset.ThumbnailMd,
+        ThumbnailLg = asset.ThumbnailLg,
+    };
+
+    /// <summary>Map a list of Asset entities to response DTOs.</summary>
+    public static List<AssetResponseDto> ToDtoList(IEnumerable<Asset> assets)
+        => assets.Select(ToDto).ToList();
+
+    /// <summary>
+    /// Create a generic file Asset from primitive parameters.
+    /// Replaces the removed AssetFactory.FromDto to keep Factory DTO-free.
+    /// </summary>
+    public static Asset CreateFileFromDto(CreateAssetDto dto, string userId)
+        => AssetFactory.CreateFile(dto.FileName.Trim(), dto.FilePath.Trim(), dto.CollectionId, userId, dto.ParentFolderId);
+}

--- a/VAH.Backend/Services/AssetService.cs
+++ b/VAH.Backend/Services/AssetService.cs
@@ -105,7 +105,7 @@ public class AssetService : IAssetService
 
         return new PagedResult<AssetResponseDto>
         {
-            Items = items.Select(a => a.ToDto()).ToList(),
+            Items = AssetMapper.ToDtoList(items),
             TotalCount = totalCount,
             Page = pagination.Page,
             PageSize = pagination.PageSize
@@ -115,16 +115,16 @@ public class AssetService : IAssetService
     public async Task<AssetResponseDto> GetByIdAsync(int id, string userId, CancellationToken ct = default)
     {
         var asset = await FindAssetWithAccessAsync(id, userId, CollectionRoles.Viewer, ct);
-        return asset.ToDto();
+        return AssetMapper.ToDto(asset);
     }
 
     public async Task<AssetResponseDto> CreateAssetAsync(CreateAssetDto dto, string userId, CancellationToken ct = default)
     {
-        var asset = AssetFactory.FromDto(dto, userId);
+        var asset = AssetMapper.CreateFileFromDto(dto, userId);
         _context.Assets.Add(asset);
         await _context.SaveChangesAsync(ct);
         await _notifier.NotifyAsync(userId, "AssetCreated", new { asset.Id, asset.FileName }, ct);
-        return asset.ToDto();
+        return AssetMapper.ToDto(asset);
     }
 
     public async Task<IReadOnlyList<AssetResponseDto>> UploadFilesAsync(IReadOnlyCollection<UploadedFileDto> files, int collectionId, int? folderId, string userId, CancellationToken ct = default)
@@ -214,7 +214,7 @@ public class AssetService : IAssetService
             await _context.SaveChangesAsync(ct);
 
         await _notifier.NotifyAsync(userId, "AssetsUploaded", new { count = createdAssets.Count, collectionId }, ct);
-        return createdAssets.Select(a => a.ToDto()).ToList();
+        return AssetMapper.ToDtoList(createdAssets);
     }
 
     public async Task<AssetResponseDto> UpdatePositionAsync(int id, double positionX, double positionY, string userId, CancellationToken ct = default)
@@ -224,7 +224,7 @@ public class AssetService : IAssetService
         asset.UpdatePosition(positionX, positionY);
         await _context.SaveChangesAsync(ct);
 
-        return asset.ToDto();
+        return AssetMapper.ToDto(asset);
     }
 
     public async Task<AssetResponseDto> CreateFolderAsync(CreateFolderDto dto, string userId, CancellationToken ct = default)
@@ -237,27 +237,19 @@ public class AssetService : IAssetService
 
         _context.Assets.Add(folder);
         await _context.SaveChangesAsync(ct);
-        return folder.ToDto();
+        return AssetMapper.ToDto(folder);
     }
 
     public async Task<AssetResponseDto> CreateColorAsync(CreateColorDto dto, string userId, CancellationToken ct = default)
     {
-        if (string.IsNullOrWhiteSpace(dto.ColorCode))
-            throw new ArgumentException("Color code is required.");
-
-        // Normalize: auto-prepend # for hex color codes
-        var code = dto.ColorCode.Trim();
-        if (!code.StartsWith('#') && System.Text.RegularExpressions.Regex.IsMatch(code, @"^[0-9A-Fa-f]{3,8}$"))
-            code = "#" + code;
-
         var ownerId = await ResolveAssetOwnerAsync(dto.CollectionId, userId, ct);
         var color = AssetFactory.CreateColor(
-            code, dto.CollectionId, ownerId,
+            dto.ColorCode, dto.CollectionId, ownerId,
             dto.ColorName, dto.GroupId, dto.ParentFolderId, dto.SortOrder ?? 0);
 
         _context.Assets.Add(color);
         await _context.SaveChangesAsync(ct);
-        return color.ToDto();
+        return AssetMapper.ToDto(color);
     }
 
     public async Task<AssetResponseDto> CreateColorGroupAsync(CreateColorGroupDto dto, string userId, CancellationToken ct = default)
@@ -272,38 +264,39 @@ public class AssetService : IAssetService
 
         _context.Assets.Add(group);
         await _context.SaveChangesAsync(ct);
-        return group.ToDto();
+        return AssetMapper.ToDto(group);
     }
 
     public async Task<AssetResponseDto> CreateLinkAsync(CreateLinkDto dto, string userId, CancellationToken ct = default)
     {
-        if (string.IsNullOrWhiteSpace(dto.Name))
-            throw new ArgumentException("Name is required.");
-        if (string.IsNullOrWhiteSpace(dto.Url))
-            throw new ArgumentException("URL is required.");
-
-        // Basic URL validation
-        if (!Uri.TryCreate(dto.Url, UriKind.Absolute, out var uri) ||
-            (uri.Scheme != "http" && uri.Scheme != "https"))
-            throw new ArgumentException("Invalid URL format. Must be http or https.");
-
         var ownerId = await ResolveAssetOwnerAsync(dto.CollectionId, userId, ct);
         var link = AssetFactory.CreateLink(
-            dto.Name.Trim(), dto.Url.Trim(), dto.CollectionId, ownerId, dto.ParentFolderId);
+            dto.Name, dto.Url, dto.CollectionId, ownerId, dto.ParentFolderId);
 
         _context.Assets.Add(link);
         await _context.SaveChangesAsync(ct);
-        return link.ToDto();
+        return AssetMapper.ToDto(link);
     }
 
     public async Task<AssetResponseDto> UpdateAssetAsync(int id, UpdateAssetDto dto, string userId, CancellationToken ct = default)
     {
         var asset = await FindAssetWithAccessAsync(id, userId, CollectionRoles.Editor, ct);
 
-        asset.ApplyUpdate(dto);
+        if (!string.IsNullOrEmpty(dto.FileName))
+            asset.Rename(dto.FileName);
+        if (dto.SortOrder.HasValue)
+            asset.Reorder(dto.SortOrder.Value);
+        if (dto.ClearGroup == true)
+            asset.RemoveFromGroup();
+        else if (dto.GroupId.HasValue)
+            asset.AssignToGroup(dto.GroupId.Value);
+        if (dto.ClearParentFolder == true)
+            asset.MoveToFolder(null);
+        else if (dto.ParentFolderId.HasValue)
+            asset.MoveToFolder(dto.ParentFolderId.Value);
 
         await _context.SaveChangesAsync(ct);
-        return asset.ToDto();
+        return AssetMapper.ToDto(asset);
     }
 
     public async Task<bool> DeleteAssetAsync(int id, string userId, CancellationToken ct = default)
@@ -356,7 +349,7 @@ public class AssetService : IAssetService
         {
             if (assetMap.TryGetValue(assetIds[i], out var asset))
             {
-                asset.SortOrder = i;
+                asset.Reorder(i);
             }
         }
 
@@ -377,18 +370,18 @@ public class AssetService : IAssetService
             if (a.UserId == userId || await _permissions.HasPermissionAsync(a.CollectionId, userId, CollectionRoles.Viewer))
                 result.Add(a);
         }
-        return result.Select(a => a.ToDto()).ToList();
+        return AssetMapper.ToDtoList(result);
     }
 
     public async Task<AssetResponseDto> DuplicateAssetAsync(int id, int? targetFolderId, string userId, CancellationToken ct = default)
     {
         var source = await FindAssetWithAccessAsync(id, userId, CollectionRoles.Editor, ct);
 
-        var clone = AssetFactory.Duplicate(source, userId, targetFolderId);
+        var clone = AssetFactory.Duplicate(source, userId, copySuffix: " (copy)", targetFolderId);
 
         _context.Assets.Add(clone);
         await _context.SaveChangesAsync(ct);
         await _notifier.NotifyAsync(userId, "AssetCreated", new { clone.Id, clone.FileName }, ct);
-        return clone.ToDto();
+        return AssetMapper.ToDto(clone);
     }
 }

--- a/VAH.Backend/Services/BulkAssetService.cs
+++ b/VAH.Backend/Services/BulkAssetService.cs
@@ -132,7 +132,10 @@ public class BulkAssetService : IBulkAssetService
         // Set group for each moved asset
         foreach (var asset in movedAssets)
         {
-            asset.GroupId = dto.TargetGroupId;
+            if (dto.TargetGroupId.HasValue)
+                asset.AssignToGroup(dto.TargetGroupId.Value);
+            else
+                asset.RemoveFromGroup();
         }
 
         // Get all existing colors in the target group (excluding the ones being moved)
@@ -172,7 +175,7 @@ public class BulkAssetService : IBulkAssetService
         // Assign sort orders
         for (int i = 0; i < finalOrder.Count; i++)
         {
-            finalOrder[i].SortOrder = i;
+            finalOrder[i].Reorder(i);
         }
 
         await _context.SaveChangesAsync(ct);

--- a/VAH.Backend/Services/CollectionService.cs
+++ b/VAH.Backend/Services/CollectionService.cs
@@ -135,7 +135,7 @@ public class CollectionService : ICollectionService
         return new CollectionWithItemsResult
         {
             Collection = collection,
-            Items = items.Select(a => a.ToDto()).ToList(),
+            Items = AssetMapper.ToDtoList(items),
             SubCollections = subcollections
         };
     }

--- a/VAH.Backend/Services/SearchService.cs
+++ b/VAH.Backend/Services/SearchService.cs
@@ -73,7 +73,7 @@ public class SearchService : ISearchService
         return new SearchResult
         {
             Query = query ?? string.Empty,
-            Assets = assets.Select(a => a.ToDto()).ToList(),
+            Assets = AssetMapper.ToDtoList(assets),
             TotalAssets = totalAssets,
             Collections = collections,
             TotalCollections = totalCollections,

--- a/VAH.Backend/Services/SmartCollectionService.cs
+++ b/VAH.Backend/Services/SmartCollectionService.cs
@@ -90,7 +90,7 @@ public class SmartCollectionService : ISmartCollectionService
 
         return new PagedResult<AssetResponseDto>
         {
-            Items = items.Select(a => a.ToDto()).ToList(),
+            Items = AssetMapper.ToDtoList(items),
             TotalCount = totalCount,
             Page = pagination.Page,
             PageSize = pagination.PageSize

--- a/docs/01_DESIGN_PHILOSOPHY/PATTERN_CATALOG.md
+++ b/docs/01_DESIGN_PHILOSOPHY/PATTERN_CATALOG.md
@@ -1,7 +1,7 @@
 # PATTERN CATALOG — Design Patterns in VAH
 
-> **Last Updated**: 2026-03-08  
-> **Total Patterns Identified**: 20
+> **Last Updated**: 2026-03-13  
+> **Total Patterns Identified**: 22
 
 ---
 
@@ -9,9 +9,11 @@
 
 ### Factory Method — `AssetFactory`
 - **File**: [Models/AssetFactory.cs](../../VAH.Backend/Models/AssetFactory.cs)
-- **Problem**: Creating correct TPH subtype (`ImageAsset`, `LinkAsset`, etc.) with consistent defaults
-- **Solution**: Static factory methods (`CreateImage`, `CreateFolder`, `CreateColor`, `CreateLink`, `CreateColorGroup`, `CreateFile`, `Duplicate`, `FromDto`)
-- **OCP**: Adding new asset type = add new factory method + TPH subclass
+- **Problem**: Creating correct TPH subtype (`FileAsset`, `ImageAsset`, `LinkAsset`, etc.) with consistent defaults and validated input
+- **Solution**: Static factory methods (`CreateImage`, `CreateFile`, `CreateFolder`, `CreateColor`, `CreateLink`, `CreateColorGroup`, `Duplicate`) accepting only primitives — never DTOs
+- **Validation**: `CreateColor` delegates to `AssetValidator.NormalizeHexColor()`, `CreateLink` to `AssetValidator.ValidateUrl()`, all methods use `ArgumentException.ThrowIfNullOrWhiteSpace` guard clauses
+- **Clone**: `Duplicate` uses virtual `InitializeClone()` for subtype-specific property copying (Url, HexCode)
+- **OCP**: Adding new asset type = add new factory method + sealed TPH subclass
 
 ### Abstract Factory — `IAssetDuplicateStrategyFactory`
 - **File**: [Features/Assets/Application/Duplicate/](../../VAH.Backend/Features/Assets/Application/Duplicate/)
@@ -58,10 +60,21 @@
 - **Problem**: Duplicate in-place vs duplicate to target folder have different logic
 - **Solution**: `InPlaceDuplicateStrategy`, `TargetFolderDuplicateStrategy` selected by factory
 
-### Template Method — `Asset` Virtual Properties
-- **File**: [Models/Asset.cs](../../VAH.Backend/Models/Asset.cs)
-- **Problem**: Different asset types need different behavior for cleanup, thumbnails, file presence
-- **Solution**: `virtual bool HasPhysicalFile`, `CanHaveThumbnails`, `RequiresFileCleanup` — subtypes override
+### Template Method — `Asset` Virtual Properties & `InitializeClone`
+- **File**: [Models/Asset.cs](../../VAH.Backend/Models/Asset.cs), [Models/AssetTypes.cs](../../VAH.Backend/Models/AssetTypes.cs)
+- **Problem**: Different asset types need different behavior for cleanup, thumbnails, file presence, and duplication
+- **Solution**: `virtual bool HasPhysicalFile`, `CanHaveThumbnails` — subtypes override. `internal virtual void InitializeClone()` — `LinkAsset` copies `Url`, `ColorAsset` copies `HexCode`
+
+### Validator — `AssetValidator`
+- **File**: [Models/AssetValidator.cs](../../VAH.Backend/Models/AssetValidator.cs)
+- **Problem**: Color hex / URL / filename validation logic scattered across Factory and Service
+- **Solution**: Static centralized validator with `[GeneratedRegex]` (source-generated) for zero-allocation regex. 3 validate methods (`NormalizeHexColor`, `ValidateUrl`, `ValidateFileName`) + 2 bool predicates
+- **Integration**: Called by `AssetFactory` pre-construction — invalid data never reaches domain entities
+
+### Mapper — `AssetMapper`
+- **File**: [Services/AssetMapper.cs](../../VAH.Backend/Services/AssetMapper.cs)
+- **Problem**: DTO mapping in domain entity violates SRP and couples domain to presentation
+- **Solution**: Static mapper in service layer (`ToDto`, `ToDtoList`, `CreateFileFromDto`). Replaces old `Asset.ToDto()` and `AssetFactory.FromDto()`
 
 ### Action Filter — `ValidateBatchFilterAttribute`
 - **File**: [Controllers/Filters/ValidateBatchFilterAttribute.cs](../../VAH.Backend/Controllers/Filters/ValidateBatchFilterAttribute.cs)

--- a/docs/02_STANDARDS/CODING_STANDARDS_BACKEND.md
+++ b/docs/02_STANDARDS/CODING_STANDARDS_BACKEND.md
@@ -1,6 +1,6 @@
 # CODING STANDARDS — .NET 9 Backend
 
-> **Last Updated**: 2026-03-02  
+> **Last Updated**: 2026-03-13  
 > **Applies to**: `VAH.Backend/`
 
 ---
@@ -90,17 +90,19 @@ public class AssetService : IAssetService
 
 ### Entity
 ```csharp
-public class Asset
+public abstract class Asset
 {
-    public int Id { get; set; }                    // Identity
-    public string FileName { get; set; }           // Scalars
-    public int CollectionId { get; set; }          // FKs
-    public Collection? Collection { get; set; }    // Navigation
-    public virtual bool HasPhysicalFile => true;   // Behavior
-    public void UpdatePosition(double x, double y) { ... }  // Domain methods
-    public AssetResponseDto ToDto() => new() { ... };       // Mapping
+    protected Asset() { }  // EF Core materialization
+    public int Id { get; private set; }                    // Identity
+    public string FileName { get; private set; }           // Private setters — always
+    public int CollectionId { get; private set; }          // FKs
+    public Collection? Collection { get; set; }            // Navigation (EF manages)
+    public virtual bool HasPhysicalFile => true;           // Behavior
+    public void Rename(string newName) { ... }             // Domain method = only mutation path
 }
 ```
+
+**Rules**: Abstract base or sealed subtypes. **Private setters** on all value properties — mutations only through domain methods (e.g., `Rename()`, `Reorder()`, `AssignToGroup()`). Guard clauses via `ArgumentException.ThrowIfNullOrWhiteSpace`. Construction via static Factory. No DTO references in domain — mapping belongs in service layer (`AssetMapper`).
 
 ## §4 — Async/Await Rules
 
@@ -144,7 +146,7 @@ Throw domain exceptions         → GlobalExceptionHandler maps to HTTP status:
 | Rule | Rationale |
 |------|-----------|
 | Enum stored as string via converter | Backward-compatible, human-readable |
-| Global query filter for soft-delete (future) | Prevent accidental data exposure |
+| Global query filter for soft-delete (`IsDeleted`) | Prevent accidental data exposure |
 | `Include()` explicitly — no lazy loading | N+1 prevention |
 | Migrations auto-applied on startup (`db.Database.Migrate()`) | Dev/staging convenience — disable in prod |
 | `CancellationToken` passed to all EF async calls | Proper request cancellation |

--- a/docs/03_ARCHITECTURE/DOMAIN_MODEL.md
+++ b/docs/03_ARCHITECTURE/DOMAIN_MODEL.md
@@ -1,6 +1,6 @@
 # DOMAIN MODEL — Entity Relationships & Aggregates
 
-> **Last Updated**: 2026-03-02
+> **Last Updated**: 2026-03-13
 
 ---
 
@@ -46,39 +46,48 @@
 
 ### 2.1 Asset Aggregate (Root: `Asset`)
 
+> `Asset` is **abstract** — never instantiated directly. All state mutations go through domain methods; every property has a **private setter**. Subtypes are **sealed**.
+
 | Entity | Role | Invariants |
 |--------|------|-----------|
-| `Asset` (TPH base) | Aggregate root | UserId required for non-system assets; ContentType must match discriminator |
+| `Asset` (abstract TPH base) | Aggregate root | UserId required for non-system assets; ContentType must match discriminator; all properties private set |
+| `FileAsset` | TPH subtype | `HasPhysicalFile = true` — generic uploaded file |
 | `ImageAsset` | TPH subtype | `HasPhysicalFile = true`, `CanHaveThumbnails = true` |
-| `LinkAsset` | TPH subtype | `HasPhysicalFile = false` — no file on disk |
-| `ColorAsset` | TPH subtype | `HasPhysicalFile = false` — hex stored in Tags field |
+| `LinkAsset` | TPH subtype | `HasPhysicalFile = false`, semantic `Url` property |
+| `ColorAsset` | TPH subtype | `HasPhysicalFile = false`, semantic `HexCode` property |
 | `ColorGroupAsset` | TPH subtype | `HasPhysicalFile = false` — groups ColorAssets via GroupId |
 | `FolderAsset` | TPH subtype | `HasPhysicalFile = false`, `IsFolder = true` |
 | `AssetTag` | Junction entity | Composite key (AssetId, TagId) |
 
-**Domain Methods on Asset:**
+**Domain Methods on Asset (only mutation path):**
 
 ```csharp
+void Rename(string newName)                 // Guard: ThrowIfNullOrWhiteSpace
+void Reorder(int sortOrder)                 // Change display order
+void AssignToGroup(int groupId)             // Assign to color group
+void RemoveFromGroup()                      // Clear GroupId
 void UpdatePosition(double x, double y)     // Canvas layout coordinates
-void ApplyUpdate(UpdateAssetDto dto)        // Partial update (null-safe)
 void SetThumbnails(string? sm, md, lg)      // Server-generated thumbnails
 void MoveToFolder(int? folderId)            // Re-parent within collection
 void MoveToCollection(int collectionId)     // Cross-collection move
-bool IsOwnedBy(string userId)               // Ownership check
-AssetResponseDto ToDto()                    // Entity → DTO mapping
+void SoftDelete()                           // Set IsDeleted + UpdatedAt
+bool IsOwnedBy(string userId)               // Ownership check (query)
+bool IsSystemAsset                          // UserId == null (query)
 ```
+
+> **DTO mapping** is handled by `AssetMapper` (service layer), NOT by the entity.
 
 **TPH Discriminator Column**: `ContentType` (string in DB via `EnumMappings`)
 
 ```
 ContentType value  →  EF Core .NET Type
 ─────────────────────────────────────────
+"file"             →  FileAsset
 "image"            →  ImageAsset
 "link"             →  LinkAsset
 "color"            →  ColorAsset
 "color-group"      →  ColorGroupAsset
 "folder"           →  FolderAsset
-"file"             →  Asset (base, default)
 ```
 
 ### 2.2 Collection Aggregate (Root: `Collection`)
@@ -191,23 +200,43 @@ AssetTag.TagId        → Tag.Id             (Required, Cascade)
 CollectionPermission.CollectionId → Collection.Id (Required, Cascade)
 ```
 
-## §5 — Factory Pattern
+## §5 — Factory Pattern & Validation
 
-`AssetFactory` provides 8 static creation methods + 1 duplication method:
+`AssetFactory` provides 6 typed creation methods + 1 duplication method. Accepts only primitives — **never DTOs**. Input validation is handled by `AssetValidator` (pre-construction) and guard clauses.
 
 ```csharp
-static Asset CreateImage(file, path, userId, collectionId)
-static Asset CreateLink(name, url, userId, collectionId)
-static Asset CreateColor(name, hex, userId, collectionId)
-static Asset CreateColorGroup(name, userId, collectionId)
-static Asset CreateFolder(name, userId, collectionId, parentFolderId?)
-static Asset CreateFile(file, path, userId, collectionId)
-static Asset FromUploadedFile(UploadedFileDto, userId, collectionId)
-static Asset CreateForType(contentType, name, path, userId, collectionId)
-static Asset Duplicate(source, userId)
+static ImageAsset CreateImage(fileName, filePath, collectionId, userId, parentFolderId?)
+static FileAsset CreateFile(fileName, filePath, collectionId, userId, parentFolderId?)
+static FolderAsset CreateFolder(name, collectionId, userId, parentFolderId?)
+static ColorAsset CreateColor(colorCode, collectionId, userId, colorName?, groupId?, parentFolderId?, sortOrder)
+static ColorGroupAsset CreateColorGroup(groupName, collectionId, userId, parentFolderId?, sortOrder)
+static LinkAsset CreateLink(name, url, collectionId, userId, parentFolderId?)
+static Asset Duplicate(source, userId, copySuffix, targetFolderId?)
 ```
 
-Each factory method returns the correct TPH subtype (`ImageAsset`, `LinkAsset`, etc.) and sets all required fields including `CreatedAt = DateTime.UtcNow`.
+- `CreateColor` calls `AssetValidator.NormalizeHexColor()` (auto-prepend `#`, 3/4/6/8 digit hex)
+- `CreateLink` calls `AssetValidator.ValidateUrl()` (absolute http/https only)
+- All methods use `ArgumentException.ThrowIfNullOrWhiteSpace` guard clauses
+- `Duplicate` uses virtual `InitializeClone()` for subtype-specific property copying (Url, HexCode)
+- `copySuffix` is a **required** parameter (no default) for localization readiness
+
+`AssetValidator` (`Models/AssetValidator.cs`) centralizes domain validation:
+
+```csharp
+static string NormalizeHexColor(string colorCode)  // GeneratedRegex, returns "#RRGGBB"
+static string ValidateUrl(string url)               // Absolute http(s) URI only
+static string ValidateFileName(string name, int maxLength = 500)
+static bool IsValidHexColor(string colorCode)
+static bool IsValidUrl(string url)
+```
+
+DTO ↔ Entity mapping is handled by `AssetMapper` (`Services/AssetMapper.cs`):
+
+```csharp
+static AssetResponseDto ToDto(Asset asset)
+static List<AssetResponseDto> ToDtoList(IEnumerable<Asset> assets)
+static Asset CreateFileFromDto(CreateAssetDto dto, string userId)
+```
 
 ---
 
@@ -217,16 +246,20 @@ Each factory method returns the correct TPH subtype (`ImageAsset`, `LinkAsset`, 
 
 ### 6.1 Asset (Full Property List)
 
+> All properties have **private setters** — mutations only through domain methods or factory construction. `Asset` is **abstract**; concrete subtypes: `FileAsset`, `ImageAsset`, `LinkAsset`, `ColorAsset`, `ColorGroupAsset`, `FolderAsset`.
+
 | Property | Type | Constraints | Default | Description |
 |----------|------|-------------|---------|-------------|
 | `Id` | int | PK, auto-increment | — | |
 | `FileName` | string | Required, MaxLength(500) | `""` | File name or folder name |
 | `FilePath` | string | Required, MaxLength(2048) | `""` | File path, URL, or hex color |
-| `Tags` | string | MaxLength(2000) | `""` | Legacy comma-separated tags |
+| `Tags` | string | [Obsolete], MaxLength(2000) | `""` | Legacy comma-separated tags — use AssetTags |
 | `CreatedAt` | DateTime | | DB default | |
+| `UpdatedAt` | DateTime? | | null | Set by domain methods on mutation |
+| `IsDeleted` | bool | | `false` | Soft-delete flag (global query filter in DbContext) |
 | `PositionX` | double | | `0` | Canvas X position |
 | `PositionY` | double | | `0` | Canvas Y position |
-| `CollectionId` | int | FK→Collections | `1` | |
+| `CollectionId` | int | FK→Collections | — | Required, set via `AssetOptions.DefaultCollectionId` |
 | `ContentType` | `AssetContentType` | EF Core value conversion | `File` | TPH discriminator |
 | `GroupId` | int? | | null | Color group membership |
 | `ParentFolderId` | int? | | null | Self-ref folder parent |
@@ -237,6 +270,13 @@ Each factory method returns the correct TPH subtype (`ImageAsset`, `LinkAsset`, 
 | `ThumbnailMd` | string? | MaxLength(2048) | null | 400px WebP thumbnail |
 | `ThumbnailLg` | string? | MaxLength(2048) | null | 800px WebP thumbnail |
 | `AssetTags` | ICollection\<AssetTag\> | Navigation | `[]` | M2M tags |
+
+**Subtype-specific Properties (TPH columns):**
+
+| Subtype | Property | Type | Description |
+|---------|----------|------|-------------|
+| `LinkAsset` | `Url` | string? | Bookmarked URL (semantic, separate from FilePath) |
+| `ColorAsset` | `HexCode` | string? | Hex color code e.g. `#FF5733` (semantic, separate from FilePath) |
 
 ### 6.2 Collection (Full Property List)
 

--- a/docs/04_MODULES/ASSET_MODULE.md
+++ b/docs/04_MODULES/ASSET_MODULE.md
@@ -3,7 +3,7 @@
 > **Domain**: Core (Asset Management)  
 > **Status**: Active  
 > **Owner**: Backend Team  
-> **Last Updated**: 2026-03-08
+> **Last Updated**: 2026-03-13
 
 ---
 
@@ -72,14 +72,18 @@ Bài toán cốt lõi: Quản lý **đa dạng loại asset** (5+ content types)
 ├───────────────────────────────────────────────────────────────────┤
 │ DOMAIN LAYER                                                      │
 │                                                                   │
-│  Asset (base class) ← TPH discriminator: ContentType              │
+│  Asset (abstract) ← TPH discriminator: ContentType                │
+│  ├── FileAsset     (HasPhysicalFile=true)  — generic file         │
 │  ├── ImageAsset    (HasPhysicalFile=true, CanHaveThumbnails=true) │
-│  ├── LinkAsset     (HasPhysicalFile=false)                        │
-│  ├── ColorAsset    (HasPhysicalFile=false)                        │
+│  ├── LinkAsset     (HasPhysicalFile=false, Url property)          │
+│  ├── ColorAsset    (HasPhysicalFile=false, HexCode property)      │
 │  ├── ColorGroupAsset (HasPhysicalFile=false)                      │
 │  └── FolderAsset   (HasPhysicalFile=false)                        │
+│  All subtypes are sealed; all properties have private setters.    │
 │                                                                   │
-│  AssetFactory (static factory — 7 creation methods + Duplicate)   │
+│  AssetFactory (static — 6 create methods + Duplicate)             │
+│  AssetValidator (static — hex/URL/filename validation)            │
+│  AssetMapper (static — DTO↔Entity mapping, service layer)         │
 │  AssetContentType (enum — 6 values + bidirectional DB mapping)    │
 │  AssetResponseDto, CreateAssetDto, UpdateAssetDto, ...            │
 ├───────────────────────────────────────────────────────────────────┤
@@ -218,39 +222,47 @@ public interface IBulkAssetService
 
 ## §4 — Domain Entities
 
-### 4.1 `Asset` (Base Entity — TPH)
+### 4.1 `Asset` (Abstract Base Entity — TPH)
+
+> `Asset` is **abstract** with **protected constructors** and **private setters** on all value properties. Never instantiate directly — use `AssetFactory` to create concrete subtypes.
 
 ```csharp
-public class Asset
+public abstract class Asset
 {
-    // ── Identity ──
-    public int Id { get; set; }
+    // ── Constructors ──
+    protected Asset() { }  // EF Core materialization
+    protected Asset(fileName, filePath, contentType, collectionId, userId, ...); // Domain constructor
+
+    // ── Identity (private set) ──
+    public int Id { get; private set; }
     
-    // ── Core Properties ──
-    public string FileName { get; set; }    // Display name
-    public string FilePath { get; set; }    // Storage path / URL / hex code
-    public string Tags { get; set; }        // Legacy string-based tags
-    public DateTime CreatedAt { get; set; }
-    public AssetContentType ContentType { get; set; }   // TPH discriminator
+    // ── Core Properties (private set — mutation via domain methods only) ──
+    public string FileName { get; private set; }    // Display name
+    public string FilePath { get; private set; }    // Storage path / URL / hex code
+    [Obsolete] public string Tags { get; internal set; }  // Legacy — use AssetTags
+    public DateTime CreatedAt { get; private set; }
+    public AssetContentType ContentType { get; private set; }   // TPH discriminator
     
-    // ── Position & Layout ──
-    public double PositionX { get; set; }
-    public double PositionY { get; set; }
-    public int SortOrder { get; set; }
+    // ── Audit (private set) ──
+    public DateTime? UpdatedAt { get; private set; }
+    public bool IsDeleted { get; private set; }     // Soft-delete flag
     
-    // ── Hierarchy ──
-    public int CollectionId { get; set; }       // Parent collection (FK)
-    public int? GroupId { get; set; }           // Color group (FK, nullable)
-    public int? ParentFolderId { get; set; }    // Folder hierarchy (self-ref FK)
-    public bool IsFolder { get; set; }
+    // ── Position & Layout (private set) ──
+    public double PositionX { get; private set; }
+    public double PositionY { get; private set; }
+    public int SortOrder { get; private set; }
     
-    // ── Ownership ──
-    public string? UserId { get; set; }         // FK → ApplicationUser
+    // ── Hierarchy (private set) ──
+    public int CollectionId { get; private set; }
+    public int? GroupId { get; private set; }
+    public int? ParentFolderId { get; private set; }
+    public bool IsFolder { get; private set; }
+    public string? UserId { get; private set; }
     
-    // ── Thumbnails ──
-    public string? ThumbnailSm { get; set; }    // 150px WebP
-    public string? ThumbnailMd { get; set; }    // 400px WebP
-    public string? ThumbnailLg { get; set; }    // 800px WebP
+    // ── Thumbnails (private set) ──
+    public string? ThumbnailSm { get; private set; }
+    public string? ThumbnailMd { get; private set; }
+    public string? ThumbnailLg { get; private set; }
     
     // ── Navigation ──
     public ICollection<AssetTag> AssetTags { get; set; }
@@ -260,27 +272,35 @@ public class Asset
     // ── Virtual Behavior Properties (TPH Polymorphism) ──
     public virtual bool HasPhysicalFile => true;
     public virtual bool CanHaveThumbnails => false;
-    public virtual bool RequiresFileCleanup => HasPhysicalFile && FilePath.StartsWith("/uploads/");
     
-    // ── Domain Methods ──
+    // ── Domain Methods (the ONLY way to mutate state) ──
+    public void Rename(string newName);         // Guard: ThrowIfNullOrWhiteSpace
+    public void Reorder(int sortOrder);
+    public void AssignToGroup(int groupId);
+    public void RemoveFromGroup();
     public void UpdatePosition(double x, double y);
-    public void ApplyUpdate(UpdateAssetDto dto);
     public void SetThumbnails(string? sm, string? md, string? lg);
     public void MoveToFolder(int? folderId);
     public void MoveToCollection(int collectionId);
+    public void SoftDelete();
     public bool IsOwnedBy(string userId);
-    public AssetResponseDto ToDto();
+    public bool IsSystemAsset { get; }
+    
+    // ── Clone support (internal) ──
+    internal virtual void InitializeClone(Asset source, string userId, string copySuffix, int? targetFolderId);
 }
 ```
 
 **Invariants:**
 | # | Business Rule | Enforcement |
 |---|--------------|-------------|
-| INV-01 | `FileName` cannot be empty | `[Required]` + `ApplyUpdate()` trims |
+| INV-01 | `FileName` cannot be empty | `[Required]` + `Rename()` guard: `ThrowIfNullOrWhiteSpace` |
 | INV-02 | Asset belongs to exactly 1 Collection | `CollectionId` non-nullable FK |
 | INV-03 | Only owner can modify asset | `IsOwnedBy(userId)` check in Service |
-| INV-04 | ImageAsset has physical file | `HasPhysicalFile` override = `true` |
-| INV-05 | Non-image types have no physical file | `HasPhysicalFile` override = `false` |
+| INV-04 | File/ImageAsset has physical file | `HasPhysicalFile` override = `true` |
+| INV-05 | Non-file types have no physical file | `HasPhysicalFile` override = `false` |
+| INV-06 | Properties are immutable outside domain methods | All setters are `private` |
+| INV-07 | Soft-deleted assets excluded from queries | `IsDeleted` global query filter in DbContext |
 
 **Relationships:**
 
@@ -333,7 +353,7 @@ public static class AssetFactory
 | **Consistent initialization** | Mọi caller dùng chung factory → không ai quên set `UserId` hoặc `CreatedAt` |
 | **Duplicate correctness** | `Duplicate()` dùng switch expression để tạo đúng subtype từ `ContentType` enum |
 
-### 4.4 `AssetContentType` Enum
+### 4.6 `AssetContentType` Enum
 
 ```csharp
 public enum AssetContentType
@@ -355,10 +375,11 @@ Với `EnumMappings` class cung cấp bidirectional mapping giữa enum ↔ DB s
 
 | Pattern | Component | Vấn đề giải quyết |
 |---------|-----------|-------------------|
-| **TPH Inheritance** | `Asset` → 5 subtypes | Polymorphic entity với single DB table — không cần JOIN |
-| **Factory Method** | `AssetFactory` (8 static methods) | Tạo đúng TPH subtype, encapsulate creation logic |
-| **Template Method** | `Asset.ToDto()`, `HasPhysicalFile` | Shared mapping logic, type-specific behavior qua override |
-| **Strategy** (planned) | Asset validation per type | Type-specific validation rules |
+| **TPH Inheritance** | `Asset` → 6 sealed subtypes | Polymorphic entity với single DB table — không cần JOIN |
+| **Factory Method** | `AssetFactory` (6 create + Duplicate) | Tạo đúng TPH subtype, integrated validation via `AssetValidator` |
+| **Template Method** | `HasPhysicalFile`, `CanHaveThumbnails`, `InitializeClone` | Type-specific behavior qua virtual override |
+| **Validator** | `AssetValidator` (3 validate + 2 predicate methods) | Centralized domain validation with `[GeneratedRegex]` |
+| **Mapper** | `AssetMapper` (service layer) | DTO↔Entity mapping tách khỏi domain entity |
 | **CQRS** | `Commands/` + `Queries/` (MediatR) | Tách read/write operations, mỗi use case 1 handler |
 | **Mediator** | MediatR `IRequest`/`IRequestHandler` | Decouple Controller khỏi Service |
 | **Observer** | SignalR notification on CRUD | Real-time UI update khi asset thay đổi |
@@ -419,7 +440,7 @@ User (Browser)     React App          Controller           MediatR            As
 | 7 | `AssetService` | `asset.SetThumbnails(sm, md, lg)` | Domain Method |
 | 8 | `AssetService` | `_context.Assets.AddRange()` + `SaveChangesAsync()` | Unit of Work |
 | 9 | `AssetService` | `INotificationService.NotifyAssetChanged()` | Observer |
-| 10 | Return | `List<AssetResponseDto>` via `asset.ToDto()` | Template Method |
+| 10 | Return | `List<AssetResponseDto>` via `AssetMapper.ToDtoList()` | Mapper |
 
 ### 6.2 Delete Asset (with Cleanup)
 
@@ -452,7 +473,7 @@ Controller          MediatR            AssetService         AssetCleanup       S
 
 **Key OOP Decisions:**
 
-1. **`asset.RequiresFileCleanup`** — Polymorphic check. `ImageAsset` returns `true`, `LinkAsset` returns `false`. Service KHÔNG cần biết asset type cụ thể.
+1. **`AssetCleanupHelper.RequiresFileCleanup(asset)`** — Service-layer helper (moved from domain). Uses `IStorageService.Exists()` instead of hardcoded path check. `ImageAsset`/`FileAsset` return `HasPhysicalFile = true`, `LinkAsset` returns `false`. Service KHÔNG cần biết asset type cụ thể.
 2. **`asset.CanHaveThumbnails`** — Chỉ `ImageAsset` override = `true`. Thumbnail cleanup tự động bỏ qua cho non-image types.
 3. **`asset.IsOwnedBy(userId)`** — Domain method encapsulate ownership check. Nếu business rule thay đổi (team ownership), chỉ sửa 1 method.
 
@@ -626,8 +647,10 @@ public record PagedResult<T>(List<T> Items, int TotalCount, int Page, int PageSi
 
 | Test Type | Target | Coverage | Tools |
 |-----------|--------|----------|-------|
-| **Unit Tests** | `AssetFactory` (all 8 methods) | Correct subtype, correct defaults | xUnit |
-| **Unit Tests** | `Asset` domain methods | `UpdatePosition`, `ApplyUpdate`, `IsOwnedBy` | xUnit |
+| **Unit Tests** | `AssetFactory` (6 create + Duplicate) | Correct subtype, correct defaults, validation | xUnit |
+| **Unit Tests** | `AssetValidator` | Hex normalization, URL validation, edge cases | xUnit |
+| **Unit Tests** | `Asset` domain methods | `Rename`, `Reorder`, `AssignToGroup`, `RemoveFromGroup`, `MoveToFolder`, `SoftDelete` | xUnit |
+| **Unit Tests** | `AssetMapper` | DTO mapping correctness for all 6 subtypes | xUnit |
 | **Unit Tests** | `AssetService` (mocked dependencies) | Business logic, edge cases | xUnit, Moq |
 | **Integration Tests** | API endpoints (14 endpoints) | Full pipeline, DB integration | WebApplicationFactory |
 | **Integration Tests** | TPH serialization | Correct discriminator per subtype | SQLite in-memory |
@@ -648,16 +671,16 @@ public record PagedResult<T>(List<T> Items, int TotalCount, int Page, int PageSi
 
 ## §11 — Known Issues & Technical Debt
 
-| # | Issue | Severity | Planned Fix |
-|---|-------|----------|-------------|
-| 1 | `Asset` properties dùng `public set` thay vì `private set` | Medium | Phase: Stabilize (strict encapsulation) |
-| 2 | Chưa có Repository pattern — Service depend trực tiếp `AppDbContext` | Medium | Phase: Modularize (`IAssetRepository`) |
-| 3 | `AssetService` ~280 LOC — gần threshold 300 | Low | Monitor, split nếu thêm methods |
-| 4 | Zero unit test coverage | **Critical** | Phase: Stabilize (priority #1) |
-| 5 | `Tags` property là `string` (legacy) — nên dùng `AssetTag` M:N only | Low | Migration khi deprecate legacy tags |
-| 6 | `ToDto()` mapping nằm trong Entity — nên tách qua AutoMapper hoặc Extension | Low | Phase: Modularize |
-| 7 | `IAssetService` có 14 methods — gần threshold 15 | Low | Monitor, potential ISP split |
-| 8 | `AssetFactory.Duplicate()` dùng switch trên `ContentType` enum | Low | Refactor sang virtual `Clone()` method |
+| # | Issue | Severity | Planned Fix | Status |
+|---|-------|----------|-------------|--------|
+| ~~1~~ | ~~`Asset` public setters~~ | ~~Medium~~ | ~~private setters + domain methods~~ | ✅ **Resolved** — all properties have `private set`, mutations via domain methods only |
+| 2 | Chưa có Repository pattern — Service depend trực tiếp `AppDbContext` | Medium | Phase: Modularize (`IAssetRepository`) | Open |
+| 3 | `AssetService` ~280 LOC — gần threshold 300 | Low | Monitor, split nếu thêm methods | Open |
+| 4 | Zero unit test coverage | **Critical** | Phase: Stabilize (priority #1) | Open |
+| 5 | `Tags` property là `string` (legacy) — marked `[Obsolete]` | Low | Migration khi remove legacy tags | Open |
+| ~~6~~ | ~~`ToDto()` mapping in Entity~~ | ~~Low~~ | ~~Tách qua Mapper~~ | ✅ **Resolved** — moved to `AssetMapper` (service layer) |
+| 7 | `IAssetService` có 14 methods — gần threshold 15 | Low | Monitor, potential ISP split | Open |
+| ~~8~~ | ~~`Duplicate()` switch on ContentType~~ | ~~Low~~ | ~~Virtual Clone method~~ | ✅ **Resolved** — uses `InitializeClone()` virtual dispatch |
 
 ---
 

--- a/docs/07_CHANGELOG/CHANGELOG.md
+++ b/docs/07_CHANGELOG/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-> **Last Updated**: 2026-03-12
+> **Last Updated**: 2026-03-13
 
 All notable changes to the Visual Asset Hub project.
 
@@ -9,6 +9,57 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ---
 
 ## [Unreleased]
+
+---
+
+## [0.5.2] — 2026-03-13
+
+### Changed — Asset Domain Model Hardening (Enterprise-Grade)
+
+- **`Asset` → abstract class**: No longer instantiable directly; all state mutations go through domain methods with private setters
+- **New `FileAsset` subtype**: Replaces base `Asset` as the concrete type for generic files (`AssetContentType.File`)
+- **All subtypes sealed**: `FileAsset`, `ImageAsset`, `LinkAsset`, `ColorAsset`, `ColorGroupAsset`, `FolderAsset` — design intent + JIT devirtualization
+- **Private setters everywhere**: All value properties on `Asset` and subtypes use `private set` — only domain methods can mutate state
+- **Protected/internal constructors**: `Asset` has `protected` constructors; subtypes have `internal` constructors (only `AssetFactory` can create instances)
+- **`ApplyUpdate(UpdateAssetDto)` → granular domain methods**: `Rename()`, `Reorder()`, `AssignToGroup()`, `RemoveFromGroup()`, `MoveToFolder()` — each with guard clauses
+- **`Rename()` guard clause**: `ArgumentException.ThrowIfNullOrWhiteSpace` — fail-fast instead of silent return
+- **Audit properties**: Added `UpdatedAt` (DateTime?) and `IsDeleted` (bool) with soft-delete global query filter in DbContext
+- **`SoftDelete()` domain method**: Sets `IsDeleted = true` + `UpdatedAt`
+- **`RequiresFileCleanup` → `AssetCleanupHelper`**: Moved from domain entity to service-layer helper using `IStorageService.Exists()`
+
+### Added — New Domain Files
+
+| File | Purpose |
+|---|---|
+| `Models/AssetValidator.cs` | Centralized validation: `NormalizeHexColor()`, `ValidateUrl()`, `ValidateFileName()` with `[GeneratedRegex]` |
+| `Services/AssetMapper.cs` | DTO↔Entity mapping: `ToDto()`, `ToDtoList()`, `CreateFileFromDto()` — replaces `Asset.ToDto()` + `AssetFactory.FromDto()` |
+
+### Changed — AssetFactory
+
+- **Removed** `FromDto()` — replaced by `AssetMapper.CreateFileFromDto()`
+- **Accepts only primitives** — never DTOs
+- **`CreateColor()`** calls `AssetValidator.NormalizeHexColor()` (auto-prepend `#`, validates 3/4/6/8 hex digits)
+- **`CreateLink()`** calls `AssetValidator.ValidateUrl()` (absolute http/https only)
+- **`Duplicate()` copySuffix** is now a required parameter (no default) for localization readiness
+- **`Duplicate()`** uses virtual `InitializeClone()` instead of manual property copy per-type
+
+### Changed — Semantic Properties
+
+- **`LinkAsset.Url`** (string?): Dedicated URL property, separate from `FilePath`, with `IsValidUrl()` method
+- **`ColorAsset.HexCode`** (string?): Dedicated hex code property, separate from `FilePath`
+- **`InitializeClone()` overrides**: `LinkAsset` and `ColorAsset` override to copy semantic properties during duplication
+
+### Changed — Service Layer Updates
+
+- **`AssetService`**: All `.ToDto()` → `AssetMapper.ToDto/ToDtoList`, `ApplyUpdate(dto)` → individual domain method calls, inline validation removed
+- **`BulkAssetService`**: `asset.GroupId =` → `asset.AssignToGroup()`/`RemoveFromGroup()`, `SortOrder =` → `asset.Reorder()`
+- **`CollectionService`, `SearchService`, `SmartCollectionService`**: `.ToDto()` → `AssetMapper.ToDtoList()`
+- **`AppDbContext`**: `FileAsset` TPH mapping, `IsDeleted` global query filter + filtered index, `Url`/`HexCode` TPH columns
+
+### Metrics
+- 12 files changed (10 modified + 2 new)
+- 3 tech debt items resolved: #1 (public setters), #6 (ToDto in entity), #8 (switch-based Duplicate)
+- 0 build errors, 6 warnings (intentional CS0618 from [Obsolete] Tags usage)
 
 ---
 

--- a/docs/07_CHANGELOG/REFACTOR_LOG.md
+++ b/docs/07_CHANGELOG/REFACTOR_LOG.md
@@ -1,8 +1,158 @@
 # REFACTOR LOG
 
-> **Last Updated**: 2026-03-12
+> **Last Updated**: 2026-03-13
 
 Tracks completed refactoring efforts with before/after comparisons.
+
+---
+
+## RF-012 — Asset Domain Model Hardening (Abstract Base, Private Setters, Validation)
+
+**Date**: 2026-03-13
+**Scope**: Asset aggregate root, TPH subtypes, AssetFactory, domain validation, DTO mapping, service layer consumers
+**Branch**: `refactor/cqrs-immutability-options-hardening`
+
+### Summary
+
+Elevated the Asset domain model from a DTO-coupled entity with public setters to an enterprise-grade DDD aggregate root. Asset is now abstract with private setters, domain methods as the only mutation path, centralized validation via `AssetValidator`, and separated DTO mapping via `AssetMapper`.
+
+### Key Changes
+
+#### 1. Abstract Asset + FileAsset Subtype
+
+**Before**
+```csharp
+public class Asset
+{
+    public string FileName { get; set; }
+    public void ApplyUpdate(UpdateAssetDto dto) { ... }
+    public AssetResponseDto ToDto() => new() { ... };
+}
+```
+
+**After**
+```csharp
+public abstract class Asset
+{
+    protected Asset() { }  // EF Core
+    protected Asset(fileName, filePath, contentType, ...) { ... }  // Domain
+
+    public string FileName { get; private set; }
+    public void Rename(string newName) { ... }  // Guard: ThrowIfNullOrWhiteSpace
+}
+
+public sealed class FileAsset : Asset  // New concrete subtype for ContentType.File
+{
+    internal FileAsset() { }
+    internal FileAsset(fileName, filePath, collectionId, userId, parentFolderId?) : base(...) { }
+}
+```
+
+#### 2. Private Setters + Domain Methods
+
+**Before**
+```csharp
+asset.FileName = dto.FileName;
+asset.SortOrder = dto.SortOrder;
+asset.GroupId = dto.GroupId;
+asset.ParentFolderId = null;
+```
+
+**After**
+```csharp
+asset.Rename(dto.FileName);
+asset.Reorder(dto.SortOrder);
+asset.AssignToGroup(dto.GroupId);
+asset.MoveToFolder(null);
+```
+
+All domain methods set `UpdatedAt = DateTime.UtcNow`. `Rename()` uses `ArgumentException.ThrowIfNullOrWhiteSpace`.
+
+#### 3. AssetValidator (Centralized Validation)
+
+```csharp
+public static partial class AssetValidator
+{
+    [GeneratedRegex(@"^#?([0-9A-Fa-f]{3}|...)$")]
+    private static partial Regex HexColorPattern();
+
+    static string NormalizeHexColor(string colorCode);  // Auto-prepend #
+    static string ValidateUrl(string url);               // Absolute http(s) only
+    static string ValidateFileName(string name, int maxLength = 500);
+}
+```
+
+Integrated into `AssetFactory.CreateColor()` and `CreateLink()`.
+
+#### 4. AssetMapper (DTO Mapping Separated)
+
+**Before** (domain entity coupled to DTO):
+```csharp
+// In Asset.cs:
+public AssetResponseDto ToDto() => new() { Id = Id, FileName = FileName, ... };
+// In AssetFactory.cs:
+public static Asset FromDto(CreateAssetDto dto, string userId) { ... }
+```
+
+**After** (service-layer mapper):
+```csharp
+// In Services/AssetMapper.cs:
+public static AssetResponseDto ToDto(Asset asset) => new() { ... };
+public static List<AssetResponseDto> ToDtoList(IEnumerable<Asset> assets) => ...;
+public static Asset CreateFileFromDto(CreateAssetDto dto, string userId) => ...;
+```
+
+#### 5. Semantic Subtype Properties + Virtual Duplicate
+
+```csharp
+public sealed class LinkAsset : Asset
+{
+    public string? Url { get; private set; }             // Semantic property
+    internal override void InitializeClone(Asset source, ...) { Url = ...; }
+}
+
+public sealed class ColorAsset : Asset
+{
+    public string? HexCode { get; private set; }         // Semantic property
+    internal override void InitializeClone(Asset source, ...) { HexCode = ...; }
+}
+```
+
+#### 6. Audit Properties + Soft Delete
+
+```csharp
+public DateTime? UpdatedAt { get; private set; }  // Set by all domain methods
+public bool IsDeleted { get; private set; }        // SoftDelete() method
+
+// AppDbContext:
+modelBuilder.Entity<Asset>().HasQueryFilter(a => !a.IsDeleted);
+modelBuilder.Entity<Asset>().HasIndex(a => a.IsDeleted).HasFilter("\"IsDeleted\" = 0");
+```
+
+### Files Changed
+
+| File | Change |
+|---|---|
+| `Models/Asset.cs` | Abstract class, protected constructors, private setters, domain methods, audit properties |
+| `Models/AssetTypes.cs` | FileAsset added, all sealed, internal constructors, Url/HexCode properties, InitializeClone overrides |
+| `Models/AssetFactory.cs` | Primitives-only, AssetValidator integration, copySuffix required param, removed FromDto |
+| `Models/AssetValidator.cs` | **NEW** — Centralized validation with GeneratedRegex |
+| `Services/AssetMapper.cs` | **NEW** — DTO↔Entity mapping (replaces Asset.ToDto + AssetFactory.FromDto) |
+| `Services/AssetService.cs` | AssetMapper usage, domain method calls, removed inline validation |
+| `Services/AssetCleanupHelper.cs` | RequiresFileCleanup uses IStorageService.Exists() |
+| `Services/BulkAssetService.cs` | Domain method calls (AssignToGroup, RemoveFromGroup, Reorder) |
+| `Services/CollectionService.cs` | AssetMapper.ToDtoList() |
+| `Services/SearchService.cs` | AssetMapper.ToDtoList() |
+| `Services/SmartCollectionService.cs` | AssetMapper.ToDtoList() |
+| `Data/AppDbContext.cs` | FileAsset TPH mapping, IsDeleted query filter + index, Url/HexCode columns |
+
+### Tech Debt Resolved
+
+| # | Item | Resolution |
+|---|------|-----------|
+| #1 | Public setters | All properties have `private set` — mutations via domain methods |
+| #6 | ToDto() in Entity | Moved to `AssetMapper` (service layer) |
+| #8 | Switch-based Duplicate | Virtual `InitializeClone()` dispatch |
 
 ---
 


### PR DESCRIPTION
…domain methods, validation, mapper

- Asset  abstract class with protected constructors, private setters on all properties
- New FileAsset sealed subtype for ContentType.File
- All 6 subtypes sealed with internal constructors
- ApplyUpdate(dto)  Rename(), Reorder(), AssignToGroup(), RemoveFromGroup(), MoveToFolder()
- Guard clauses: ArgumentException.ThrowIfNullOrWhiteSpace
- Added UpdatedAt, IsDeleted (soft-delete) with global query filter
- New AssetValidator: NormalizeHexColor, ValidateUrl, ValidateFileName (GeneratedRegex)
- New AssetMapper: ToDto, ToDtoList, CreateFileFromDto (replaces Asset.ToDto + AssetFactory.FromDto)
- AssetCleanupHelper: RequiresFileCleanup moved from domain to service layer
- LinkAsset.Url, ColorAsset.HexCode semantic properties with InitializeClone overrides
- Duplicate copySuffix is required param (localization-ready)
- Updated 6 documentation files: DOMAIN_MODEL, ASSET_MODULE, PATTERN_CATALOG, CODING_STANDARDS, CHANGELOG, REFACTOR_LOG
- Resolved tech debt #1 (public setters), #6 (ToDto in entity), #8 (switch Duplicate)